### PR TITLE
Implement numeric scalar reads in the command-line deserializer

### DIFF
--- a/src/Serde.CmdLine/Deserializer.cs
+++ b/src/Serde.CmdLine/Deserializer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 
 namespace Serde.CmdLine;
 
@@ -58,33 +59,33 @@ internal sealed partial class Deserializer(string[] args, bool handleHelp) : IDe
         return d.Deserialize(this);
     }
 
-    public char ReadChar() => throw new NotImplementedException();
+    public char ReadChar() => ReadString()[0];
 
-    public byte ReadU8() => throw new NotImplementedException();
+    public byte ReadU8() => byte.Parse(ReadString(), CultureInfo.InvariantCulture);
 
-    public ushort ReadU16() => throw new NotImplementedException();
+    public ushort ReadU16() => ushort.Parse(ReadString(), CultureInfo.InvariantCulture);
 
-    public uint ReadU32() => throw new NotImplementedException();
+    public uint ReadU32() => uint.Parse(ReadString(), CultureInfo.InvariantCulture);
 
-    public ulong ReadU64() => throw new NotImplementedException();
+    public ulong ReadU64() => ulong.Parse(ReadString(), CultureInfo.InvariantCulture);
 
-    public sbyte ReadI8() => throw new NotImplementedException();
+    public sbyte ReadI8() => sbyte.Parse(ReadString(), CultureInfo.InvariantCulture);
 
-    public short ReadI16() => throw new NotImplementedException();
+    public short ReadI16() => short.Parse(ReadString(), CultureInfo.InvariantCulture);
 
-    public int ReadI32() => throw new NotImplementedException();
+    public int ReadI32() => int.Parse(ReadString(), CultureInfo.InvariantCulture);
 
-    public long ReadI64() => throw new NotImplementedException();
+    public long ReadI64() => long.Parse(ReadString(), CultureInfo.InvariantCulture);
 
-    public float ReadF32() => throw new NotImplementedException();
+    public float ReadF32() => float.Parse(ReadString(), CultureInfo.InvariantCulture);
 
-    public double ReadF64() => throw new NotImplementedException();
+    public double ReadF64() => double.Parse(ReadString(), CultureInfo.InvariantCulture);
 
-    public decimal ReadDecimal() => throw new NotImplementedException();
+    public decimal ReadDecimal() => decimal.Parse(ReadString(), CultureInfo.InvariantCulture);
     public DateTime ReadDateTime() => throw new NotImplementedException();
     public DateTimeOffset ReadDateTimeOffset() => throw new NotImplementedException();
-    public Int128 ReadI128() => throw new NotImplementedException();
-    public UInt128 ReadU128() => throw new NotImplementedException();
+    public Int128 ReadI128() => Int128.Parse(ReadString(), CultureInfo.InvariantCulture);
+    public UInt128 ReadU128() => UInt128.Parse(ReadString(), CultureInfo.InvariantCulture);
     public void ReadBytes(IBufferWriter<byte> writer) => throw new NotImplementedException();
 
     public void Dispose()

--- a/test/Serde.CmdLine.Test/CliTests.cs
+++ b/test/Serde.CmdLine.Test/CliTests.cs
@@ -115,4 +115,34 @@ Options:
         [CommandParameter(0, "arg")]
         public required string Arg { get; init; }
     }
+
+    [Fact]
+    public void NumericOptionsTest()
+    {
+        string[] cmdLine = [ "--count", "42", "--ratio", "1.5", "--big", "9000000000", "9" ];
+        var cmd = CmdLine.ParseRawWithHelp<NumericCommand>(cmdLine).Unwrap();
+        Assert.Equal(new NumericCommand
+        {
+            Count = 42,
+            Ratio = 1.5,
+            Big = 9_000_000_000L,
+            Ordinal = 9,
+        }, cmd);
+    }
+
+    [GenerateDeserialize]
+    private sealed partial record NumericCommand
+    {
+        [CommandOption("--count")]
+        public int? Count { get; init; }
+
+        [CommandOption("--ratio")]
+        public double? Ratio { get; init; }
+
+        [CommandOption("--big")]
+        public long? Big { get; init; }
+
+        [CommandParameter(0, "ordinal")]
+        public required int Ordinal { get; init; }
+    }
 }


### PR DESCRIPTION
## Problem

The command-line `Deserializer` reads option/parameter values directly out of the raw `string[]` args. `ReadString` and `ReadBool` are implemented, but every numeric scalar reader is an unimplemented stub:

```csharp
public int  ReadI32() => throw new NotImplementedException();
public long ReadI64() => throw new NotImplementedException();
// ...U8/U16/U32/U64/I8/I16/F32/F64/Decimal/Char/I128/U128 — all throw
```

So any `[CommandOption]` / `[CommandParameter]` typed as a number compiles fine but throws `NotImplementedException` at **parse time**, when the value token is read:

```
TryReadIndex matches "--count", advances past the flag → value at _args[argIndex]
  → generated proxy ReadValue<int> → NullableProxy.De<int,I32Proxy>
    → IDeserializer.ReadI32()  // throws
```

This was never caught because every option/parameter in the test suite is `string` or `bool`.

## Fix

Implement the numeric (and `char`) readers in terms of `ReadString()`, which already consumes the right token and handles both the normal path and the inherited parent-option (`_checkingSkipped`) path. Values are parsed with `CultureInfo.InvariantCulture`.

`ReadDateTime`/`ReadDateTimeOffset`/`ReadBytes` are intentionally left unimplemented (no obvious CLI mapping).

## Test

Adds `NumericOptionsTest` covering `int`, `long`, and `double` options plus an `int` parameter. Verified it fails on `main` (throws `NotImplementedException`) and passes with the fix. Full suite: 22/22 green.