### PR TITLE
Support hidden commands and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,22 @@ if (cmdOpt is {} cmd)
    // handle cmd
 }
 ```
+
+## Hidden commands and options
+
+Commands, parameters, options, and command groups can be marked as `Hidden` so they
+are still parseable but omitted from the generated help text. This is useful for
+experimental, deprecated, or internal-only functionality.
+
+```
+[GenerateDeserialize]
+internal sealed partial record FileSizeCommand
+{
+    [CommandOption("-p|--pattern")]
+    public string? SearchPattern { get; init; }
+
+    // Parses normally, but does not appear in `CmdLine.GetHelpText` output.
+    [CommandOption("--experimental", Hidden = true)]
+    public bool? Experimental { get; init; }
+}
+```

--- a/src/Serde.CmdLine/Attributes.cs
+++ b/src/Serde.CmdLine/Attributes.cs
@@ -11,6 +11,11 @@ public sealed class CommandOptionAttribute(string flagNames) : Attribute
     public string FlagNames { get; } = flagNames;
 
     public string? Description { get; init; } = null;
+
+    /// <summary>
+    /// If true, the option is still parseable but omitted from generated help text.
+    /// </summary>
+    public bool Hidden { get; init; } = false;
 }
 
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field,
@@ -23,6 +28,11 @@ public sealed class CommandParameterAttribute(int ordinal, string name) : Attrib
     public string Name { get; } = name;
 
     public string? Description { get; init; } = null;
+
+    /// <summary>
+    /// If true, the parameter is still parseable but omitted from generated help text.
+    /// </summary>
+    public bool Hidden { get; init; } = false;
 }
 
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Class,
@@ -41,6 +51,11 @@ public sealed class CommandAttribute(string name) : Attribute
     /// Detailed description of the command.
     /// </summary>
     public string? Description { get; init; } = null;
+
+    /// <summary>
+    /// If true, the command is still parseable but omitted from generated help text.
+    /// </summary>
+    public bool Hidden { get; init; } = false;
 }
 
 /// <summary>
@@ -52,4 +67,9 @@ public sealed class CommandAttribute(string name) : Attribute
 public sealed class CommandGroupAttribute(string name) : Attribute
 {
     public string Name { get; } = name;
+
+    /// <summary>
+    /// If true, the command group is still parseable but omitted from generated help text.
+    /// </summary>
+    public bool Hidden { get; init; } = false;
 }

--- a/src/Serde.CmdLine/CmdLine.cs
+++ b/src/Serde.CmdLine/CmdLine.cs
@@ -124,36 +124,39 @@ public static class CmdLine
                               ConstructorArguments: [ { Value: string flagNames } ],
                               NamedArguments: var namedArgs })
                 {
+                    if (IsHidden(namedArgs))
+                    {
+                        continue;
+                    }
                     // Consider nullable boolean fields as flag options.
 #pragma warning disable SerdeExperimentalFieldInfo
                     var optionName = targetInfo.GetFieldInfo(fieldIndex).Name == "bool?"
 #pragma warning restore SerdeExperimentalFieldInfo
                         ? null
                         : $"<{targetInfo.GetFieldStringName(fieldIndex)}>";
-                    string? desc = null;
-                    if (namedArgs is [ { MemberName: nameof(CommandParameterAttribute.Description),
-                                         TypedValue: { Value: string attrDesc } } ])
-                    {
-                        desc = attrDesc;
-                    }
+                    string? desc = GetDescription(namedArgs);
                     options.Add((flagNames.Split('|'), optionName, desc));
                 }
                 else if (attr is { AttributeType: { Name: nameof(CommandParameterAttribute) },
                                ConstructorArguments: [ { Value: int paramIndex }, { Value: string paramName } ],
                                NamedArguments: var namedArgs2 })
                 {
-                    string? desc = null;
-                    if (namedArgs2 is [ { MemberName: nameof(CommandParameterAttribute.Description),
-                                         TypedValue: { Value: string attrDesc } } ])
+                    if (IsHidden(namedArgs2))
                     {
-                        desc = attrDesc;
+                        continue;
                     }
+                    string? desc = GetDescription(namedArgs2);
                     args.Add(($"<{paramName}>", desc));
                 }
                 else if (attr is { AttributeType: { Name: nameof(CommandGroupAttribute) },
-                                   ConstructorArguments: [ { Value: string commandName }]
+                                   ConstructorArguments: [ { Value: string commandName }],
+                                   NamedArguments: var namedGroupArgs
                                  })
                 {
+                    if (IsHidden(namedGroupArgs))
+                    {
+                        continue;
+                    }
                     commandsName ??= commandName;
 #pragma warning disable SerdeExperimentalFieldInfo
                     var info = targetInfo.GetFieldInfo(fieldIndex);
@@ -169,8 +172,13 @@ public static class CmdLine
                         AddCommand(commands, caseInfo);
                     }
                 }
-                else if (attr is { AttributeType: { Name: nameof(CommandAttribute) } })
+                else if (attr is { AttributeType: { Name: nameof(CommandAttribute) },
+                                   NamedArguments: var namedCmdArgs })
                 {
+                    if (IsHidden(namedCmdArgs))
+                    {
+                        continue;
+                    }
 #pragma warning disable SerdeExperimentalFieldInfo
                     var info = targetInfo.GetFieldInfo(fieldIndex);
 #pragma warning restore SerdeExperimentalFieldInfo
@@ -195,6 +203,10 @@ public static class CmdLine
                                 NamedArguments: var namedCaseArgs
                             })
                         {
+                            if (IsHidden(namedCaseArgs))
+                            {
+                                return;
+                            }
                             cmdName = caseCmdName;
                             foreach (var namedArg in namedCaseArgs)
                             {
@@ -376,6 +388,31 @@ usage: {topLevelName}{optionsUsageShortString}{commandsName?.Map(n => $" <{n}>")
             }
         }
         return name;
+    }
+
+    private static bool IsHidden(IList<System.Reflection.CustomAttributeNamedArgument> namedArgs)
+    {
+        foreach (var namedArg in namedArgs)
+        {
+            if (namedArg is { MemberName: "Hidden", TypedValue: { Value: true } })
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static string? GetDescription(IList<System.Reflection.CustomAttributeNamedArgument> namedArgs)
+    {
+        foreach (var namedArg in namedArgs)
+        {
+            if (namedArg is { MemberName: "Description",
+                              TypedValue: { Value: string desc } })
+            {
+                return desc;
+            }
+        }
+        return null;
     }
 
 }

--- a/test/Serde.CmdLine.Test/CliTests.cs
+++ b/test/Serde.CmdLine.Test/CliTests.cs
@@ -94,6 +94,53 @@ Options:
         public bool? Help { get; init; }
     }
 
+    [GenerateDeserialize]
+    internal sealed partial record HiddenMembersCommand
+    {
+        [CommandParameter(0, "visibleArg", Description = "A visible argument.")]
+        public string? VisibleArg { get; init; }
+
+        [CommandParameter(1, "secretArg", Hidden = true)]
+        public string? SecretArg { get; init; }
+
+        [CommandOption("--visible")]
+        public bool? Visible { get; init; }
+
+        [CommandOption("--secret", Hidden = true)]
+        public bool? Secret { get; init; }
+    }
+
+    [Fact]
+    public void HiddenMembersStillParse()
+    {
+        string[] testArgs = [ "--secret", "firstArg", "secondArg" ];
+        var cmd = CmdLine.ParseRawWithHelp<HiddenMembersCommand>(testArgs).Unwrap();
+        Assert.Equal(new HiddenMembersCommand
+        {
+            VisibleArg = "firstArg",
+            SecretArg = "secondArg",
+            Visible = null,
+            Secret = true
+        }, cmd);
+    }
+
+    [Fact]
+    public void HiddenMembersNotInHelp()
+    {
+        var help = CmdLine.GetHelpText(SerdeInfoProvider.GetDeserializeInfo<HiddenMembersCommand>());
+        var text = """
+usage: HiddenMembersCommand [--visible] <visibleArg>
+
+Arguments:
+    <visibleArg>  A visible argument.
+
+Options:
+    --visible
+
+""";
+        Assert.Equal(text.NormalizeLineEndings(), help.NormalizeLineEndings());
+    }
+
     [Fact]
     public void BasicCommandTest()
     {

--- a/test/Serde.CmdLine.Test/SubCommandTests.cs
+++ b/test/Serde.CmdLine.Test/SubCommandTests.cs
@@ -190,6 +190,37 @@ Commands:
 
         [Command("second")]
         public sealed partial record SecondCommand : SubCommand;
+
+        [Command("hidden-command", Hidden = true)]
+        public sealed partial record HiddenCommand : SubCommand;
+    }
+
+    [Fact]
+    public void HiddenCommandStillParses()
+    {
+        string[] testArgs = [ "hidden-command" ];
+        var cmd = CmdLine.ParseRawWithHelp<TopCommand>(testArgs).Unwrap();
+        Assert.Equal(new TopCommand { SubCommand = new SubCommand.HiddenCommand() }, cmd);
+    }
+
+    [Fact]
+    public void HiddenCommandNotInHelp()
+    {
+        var help = CmdLine.GetHelpText(SerdeInfoProvider.GetDeserializeInfo<TopCommand>());
+        var text = """
+usage: TopCommand [-v | --verbose] [-h | --help] [-t | --string-option <stringOption>] <command>
+
+Options:
+    -v, --verbose
+    -h, --help
+    -t, --string-option  <stringOption>
+
+Commands:
+    first
+    second
+
+""";
+        Assert.Equal(text.NormalizeLineEndings(), help.NormalizeLineEndings());
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #46.

## Summary

Allow commands, subcommands, parameters, and options to be marked as *hidden* so they are still parseable but omitted from generated help text — useful for experimental, deprecated, or internal-only functionality.

## Changes

- **`Attributes.cs`** — Added a `Hidden` named property (default `false`) to `CommandOptionAttribute`, `CommandParameterAttribute`, `CommandAttribute`, and `CommandGroupAttribute`.
- **`CmdLine.cs`** — `GetHelpText` now skips fields whose attribute has `Hidden = true` when building the `args`, `options`, and `commands` lists (including commands within a group). Parsing is untouched, so hidden members still parse normally.
- **`README.md`** — Documented the feature.

## Tests

- `HiddenMembersStillParse` / `HiddenMembersNotInHelp` — hidden option + parameter.
- `HiddenCommandStillParses` / `HiddenCommandNotInHelp` — hidden subcommand.

All 26 unit tests + 4 analyzer tests pass.